### PR TITLE
Update GitHub Actions workflow name to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "build-test"
+name: ci
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/gradle/wrapper-validation-action/actions"><img alt="gradle/wrapper-validation-action status" src="https://github.com/gradle/wrapper-validation-action/workflows/build-test/badge.svg"></a>
+  <a href="https://github.com/gradle/wrapper-validation-action/actions"><img alt="gradle/wrapper-validation-action status" src="https://github.com/gradle/wrapper-validation-action/workflows/ci/badge.svg"></a>
 </p>
 
 # Gradle Wrapper Validation Action


### PR DESCRIPTION
Minor simplification and alignment of the GitHub Actions workflow name:

- The filename now matches the `name` field
- The badge now simply reads "ci passing" (like in many other repos) instead of "build-test passing"