### PR TITLE
Autoupdate github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
**Summary**
This will keep stuff like `- uses: actions/checkout@v2` updated (v3 is latest) in Github Actions, e.g. in the [CI Action](https://github.com/gradle/wrapper-validation-action/blob/master/.github/workflows/ci.yml#L13)

> Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and **safer**. When you enable Dependabot version updates for GitHub Actions, Dependabot will help ensure that references to actions in a repository's workflow.yml file are kept up to date.
~ https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

Update frequency could probably be daily - I don't think there'll be _loads_ of major version changes :)