### PR TITLE
Use actions/checkout@v3 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
 ```
 


### PR DESCRIPTION
This PR changes to use `actions/checkout@v3` in `README.md`.