### PR TITLE
Check if checksums endpoint returned status 200

### DIFF
--- a/src/checksums.ts
+++ b/src/checksums.ts
@@ -36,5 +36,8 @@ async function httpGetJsonArray(url: string): Promise<unknown[]> {
 
 async function httpGetText(url: string): Promise<string> {
   const response = await httpc.get(url)
+  if (response.message.statusCode !== 200) {
+    throw Error(`Invalid status code returned by checksums endpoint: ${response.message.statusCode}`)
+  }
   return await response.readBody()
 }


### PR DESCRIPTION
`HttpClient` in `typed-rest-client` does not throw for error status codes so it should be checked manually.  Client follows redirects by default (status code 3xx) so I think comparing with status 200 should be good. It may improve situation for people affected by #57 by giving more information about the issue