### PR TITLE
Export failed wrapper(s) path to `GITHUB_OUTPUT`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  failed-wrapper:
+    description: The path of the Gradle Wrapper(s) JAR that failed validation.
+
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -212,6 +212,9 @@ async function run() {
         }
         else {
             core.setFailed(`Gradle Wrapper Validation Failed!\n  See https://github.com/gradle/wrapper-validation-action#reporting-failures\n${result.toDisplayString()}`);
+            if (result.invalid.length > 0) {
+                core.setOutput('failed-wrapper', `${result.invalid.map(w => w.path).join('|')}`);
+            }
         }
     }
     catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,12 @@ export async function run(): Promise<void> {
       core.setFailed(
         `Gradle Wrapper Validation Failed!\n  See https://github.com/gradle/wrapper-validation-action#reporting-failures\n${result.toDisplayString()}`
       )
+      if (result.invalid.length > 0) {
+        core.setOutput(
+          'failed-wrapper',
+          `${result.invalid.map(w => w.path).join('|')}`
+        )
+      }
     }
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
Rebased version of #134