### PR TITLE
Introduce configuration option to detect gradle versions from `gradle-wrapper.properties`

### DIFF
--- a/__tests__/checksums.test.ts
+++ b/__tests__/checksums.test.ts
@@ -5,8 +5,15 @@ import {afterEach, describe, expect, test, jest} from '@jest/globals'
 jest.setTimeout(30000)
 
 test('fetches wrapper jars checksums', async () => {
-  const validChecksums = await checksums.fetchValidChecksums(false)
+  const validChecksums = await checksums.fetchValidChecksums(false, false, [])
   expect(validChecksums.length).toBeGreaterThan(10)
+})
+
+test('fetches wrapper jars checksums only for detected versions', async () => {
+  const validChecksums = await checksums.fetchValidChecksums(false, true, [
+    '8.2.1'
+  ])
+  expect(validChecksums.length).toBe(1)
 })
 
 describe('retry', () => {
@@ -24,7 +31,11 @@ describe('retry', () => {
           code: 'ECONNREFUSED'
         })
 
-      const validChecksums = await checksums.fetchValidChecksums(false)
+      const validChecksums = await checksums.fetchValidChecksums(
+        false,
+        false,
+        []
+      )
       expect(validChecksums.length).toBeGreaterThan(10)
       nock.isDone()
     })

--- a/__tests__/data/invalid/gradle-wrapper.properties
+++ b/__tests__/data/invalid/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle8.2.1bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/__tests__/data/valid/gradle-wrapper.properties
+++ b/__tests__/data/valid/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-milestone-3-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true

--- a/__tests__/find.test.ts
+++ b/__tests__/find.test.ts
@@ -10,3 +10,13 @@ test('finds test data wrapper jars', async () => {
   expect(wrapperJars).toContain('__tests__/data/invalid/gradle-wrapper.jar')
   expect(wrapperJars).toContain('__tests__/data/invalid/gradlе-wrapper.jar') // homoglyph
 })
+
+test('detect version from `gradle-wrapper.properties` alongside wrappers', async () => {
+  const repoRoot = path.resolve('.')
+  const wrapperJars = await find.findWrapperJars(repoRoot)
+
+  const detectedVersions = await find.detectVersions(wrapperJars)
+
+  expect(detectedVersions.length).toBe(1)
+  expect(detectedVersions).toContain('6.1-milestone-3')
+})

--- a/__tests__/validate.test.ts
+++ b/__tests__/validate.test.ts
@@ -7,9 +7,13 @@ jest.setTimeout(30000)
 const baseDir = path.resolve('.')
 
 test('succeeds if all found wrapper jars are valid', async () => {
-  const result = await validate.findInvalidWrapperJars(baseDir, 3, false, [
-    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-  ])
+  const result = await validate.findInvalidWrapperJars(
+    baseDir,
+    3,
+    false,
+    ['e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    false
+  )
 
   expect(result.isValid()).toBe(true)
 
@@ -22,7 +26,51 @@ test('succeeds if all found wrapper jars are valid', async () => {
 })
 
 test('fails if invalid wrapper jars are found', async () => {
-  const result = await validate.findInvalidWrapperJars(baseDir, 3, false, [])
+  const result = await validate.findInvalidWrapperJars(
+    baseDir,
+    3,
+    false,
+    [],
+    false
+  )
+
+  expect(result.isValid()).toBe(false)
+
+  expect(result.valid).toEqual([
+    new validate.WrapperJar(
+      '__tests__/data/valid/gradle-wrapper.jar',
+      '3888c76faa032ea8394b8a54e04ce2227ab1f4be64f65d450f8509fe112d38ce'
+    )
+  ])
+
+  expect(result.invalid).toEqual([
+    new validate.WrapperJar(
+      '__tests__/data/invalid/gradle-wrapper.jar',
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    ),
+    new validate.WrapperJar(
+      '__tests__/data/invalid/gradlе-wrapper.jar', // homoglyph
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    )
+  ])
+
+  expect(result.toDisplayString()).toBe(
+    '✗ Found unknown Gradle Wrapper JAR files:\n' +
+      '  e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 __tests__/data/invalid/gradle-wrapper.jar\n' +
+      '  e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 __tests__/data/invalid/gradlе-wrapper.jar\n' + // homoglyph
+      '✓ Found known Gradle Wrapper JAR files:\n' +
+      '  3888c76faa032ea8394b8a54e04ce2227ab1f4be64f65d450f8509fe112d38ce __tests__/data/valid/gradle-wrapper.jar'
+  )
+})
+
+test('fails if invalid wrapper jars are found when detection versions from `gradle-wrapper.properties`', async () => {
+  const result = await validate.findInvalidWrapperJars(
+    baseDir,
+    3,
+    false,
+    [],
+    true
+  )
 
   expect(result.isValid()).toBe(false)
 
@@ -54,7 +102,13 @@ test('fails if invalid wrapper jars are found', async () => {
 })
 
 test('fails if not enough wrapper jars are found', async () => {
-  const result = await validate.findInvalidWrapperJars(baseDir, 4, false, [])
+  const result = await validate.findInvalidWrapperJars(
+    baseDir,
+    4,
+    false,
+    [],
+    false
+  )
 
   expect(result.isValid()).toBe(false)
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Accept arbitrary user-defined checksums as valid. Comma separated list of SHA256 checksums (lowercase hex).'
     required: false
     default: ''
+  detect-version:
+    description: 'Searches for the Gradle version defined in the graler-wrapper.properties file to limit checksum verification to these versions. Boolean, true or false.'
+    required: false
+    default: 'false'
 
 outputs:
   failed-wrapper:

--- a/dist/index.js
+++ b/dist/index.js
@@ -33,14 +33,15 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.fetchValidChecksums = void 0;
 const httpm = __importStar(__nccwpck_require__(5538));
 const httpc = new httpm.HttpClient('gradle/wrapper-validation-action', undefined, { allowRetries: true, maxRetries: 3 });
-async function fetchValidChecksums(allowSnapshots) {
+async function fetchValidChecksums(allowSnapshots, detectVersions, detectedVersions) {
     const all = await httpGetJsonArray('https://services.gradle.org/versions/all');
     const withChecksum = all.filter(entry => typeof entry === 'object' &&
         entry != null &&
         entry.hasOwnProperty('wrapperChecksumUrl'));
     const allowed = withChecksum.filter(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (entry) => allowSnapshots || !entry.snapshot);
+    (entry) => (allowSnapshots || !entry.snapshot) &&
+        (!detectVersions || detectedVersions.includes(entry.version)));
     const checksumUrls = allowed.map(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (entry) => entry.wrapperChecksumUrl);
@@ -91,12 +92,16 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.findWrapperJars = void 0;
+exports.detectVersions = exports.findWrapperJars = void 0;
 const util = __importStar(__nccwpck_require__(3837));
 const path = __importStar(__nccwpck_require__(1017));
 const fs = __importStar(__nccwpck_require__(7147));
+const readline = __importStar(__nccwpck_require__(4521));
 const unhomoglyph_1 = __importDefault(__nccwpck_require__(8708));
+const events_1 = __importDefault(__nccwpck_require__(2361));
+const core = __importStar(__nccwpck_require__(2186));
 const readdir = util.promisify(fs.readdir);
+const versionRegex = new RegExp(/\/gradle-(.+)-/);
 async function findWrapperJars(baseDir) {
     const files = await recursivelyListFiles(baseDir);
     return files
@@ -105,6 +110,48 @@ async function findWrapperJars(baseDir) {
         .sort((a, b) => a.localeCompare(b));
 }
 exports.findWrapperJars = findWrapperJars;
+async function detectVersions(wrapperJars) {
+    return (await Promise.all(wrapperJars.map(async (wrapperJar) => await findWrapperVersion(wrapperJar)))).filter(version => version !== undefined);
+}
+exports.detectVersions = detectVersions;
+async function findWrapperVersion(wrapperJar) {
+    const jar = path.parse(wrapperJar);
+    const properties = path.resolve(jar.dir, 'gradle-wrapper.properties');
+    if (fs.existsSync(properties)) {
+        try {
+            const lineReader = readline.createInterface({
+                input: fs.createReadStream(properties)
+            });
+            let distributionUrl = '';
+            lineReader.on('line', function (line) {
+                if (line.startsWith('distributionUrl=')) {
+                    distributionUrl = line;
+                    lineReader.close();
+                }
+            });
+            await events_1.default.once(lineReader, 'close');
+            if (distributionUrl) {
+                const matchedVersion = distributionUrl.match(versionRegex);
+                if (matchedVersion && matchedVersion.length >= 1) {
+                    return matchedVersion[1];
+                }
+                else {
+                    core.debug(`Could not parse version from distributionUrl in gradle-wrapper.properties file: ${properties}`);
+                }
+            }
+            else {
+                core.debug(`Could not identify valid distributionUrl in gradle-wrapper.properties file: ${properties}`);
+            }
+        }
+        catch (error) {
+            core.warning(`Failed to retrieve version from gradle-wrapper.properties file: ${properties} due to ${error}`);
+        }
+    }
+    else {
+        core.debug(`No gradle-wrapper.properties file existed alongside ${wrapperJar}`);
+    }
+    return undefined;
+}
 async function recursivelyListFiles(baseDir) {
     const childrenNames = await readdir(baseDir);
     const childrenPaths = await Promise.all(childrenNames.map(async (childName) => {
@@ -206,7 +253,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const validate = __importStar(__nccwpck_require__(1997));
 async function run() {
     try {
-        const result = await validate.findInvalidWrapperJars(path.resolve('.'), +core.getInput('min-wrapper-count'), core.getInput('allow-snapshots') === 'true', core.getInput('allow-checksums').split(','));
+        const result = await validate.findInvalidWrapperJars(path.resolve('.'), +core.getInput('min-wrapper-count'), core.getInput('allow-snapshots') === 'true', core.getInput('allow-checksums').split(','), core.getInput('detect-version') === 'true');
         if (result.isValid()) {
             core.info(result.toDisplayString());
         }
@@ -265,14 +312,21 @@ exports.WrapperJar = exports.ValidationResult = exports.findInvalidWrapperJars =
 const find = __importStar(__nccwpck_require__(548));
 const checksums = __importStar(__nccwpck_require__(4382));
 const hash = __importStar(__nccwpck_require__(1859));
-async function findInvalidWrapperJars(gitRepoRoot, minWrapperCount, allowSnapshots, allowChecksums) {
+async function findInvalidWrapperJars(gitRepoRoot, minWrapperCount, allowSnapshots, allowChecksums, detectVersions) {
     const wrapperJars = await find.findWrapperJars(gitRepoRoot);
     const result = new ValidationResult([], []);
     if (wrapperJars.length < minWrapperCount) {
         result.errors.push(`Expected to find at least ${minWrapperCount} Gradle Wrapper JARs but got only ${wrapperJars.length}`);
     }
     if (wrapperJars.length > 0) {
-        const validChecksums = await checksums.fetchValidChecksums(allowSnapshots);
+        let detectedVersions;
+        if (detectVersions) {
+            detectedVersions = await find.detectVersions(wrapperJars);
+        }
+        else {
+            detectedVersions = [];
+        }
+        const validChecksums = await checksums.fetchValidChecksums(allowSnapshots, detectVersions, detectedVersions);
         validChecksums.push(...allowChecksums);
         for (const wrapperJar of wrapperJars) {
             const sha = await hash.sha256File(wrapperJar);
@@ -5942,6 +5996,14 @@ module.exports = require("os");
 
 "use strict";
 module.exports = require("path");
+
+/***/ }),
+
+/***/ 4521:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("readline");
 
 /***/ }),
 

--- a/src/checksums.ts
+++ b/src/checksums.ts
@@ -7,7 +7,9 @@ const httpc = new httpm.HttpClient(
 )
 
 export async function fetchValidChecksums(
-  allowSnapshots: boolean
+  allowSnapshots: boolean,
+  detectVersions: boolean,
+  detectedVersions: string[]
 ): Promise<string[]> {
   const all = await httpGetJsonArray('https://services.gradle.org/versions/all')
   const withChecksum = all.filter(
@@ -18,7 +20,9 @@ export async function fetchValidChecksums(
   )
   const allowed = withChecksum.filter(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (entry: any) => allowSnapshots || !entry.snapshot
+    (entry: any) =>
+      (allowSnapshots || !entry.snapshot) &&
+      (!detectVersions || detectedVersions.includes(entry.version))
   )
   const checksumUrls = allowed.map(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,9 +1,13 @@
 import * as util from 'util'
 import * as path from 'path'
 import * as fs from 'fs'
+import * as readline from 'readline'
 import unhomoglyph from 'unhomoglyph'
+import events from 'events'
+import * as core from '@actions/core'
 
 const readdir = util.promisify(fs.readdir)
+const versionRegex = new RegExp(/\/gradle-(.+)-/)
 
 export async function findWrapperJars(baseDir: string): Promise<string[]> {
   const files = await recursivelyListFiles(baseDir)
@@ -11,6 +15,63 @@ export async function findWrapperJars(baseDir: string): Promise<string[]> {
     .filter(file => unhomoglyph(file).endsWith('gradle-wrapper.jar'))
     .map(wrapperJar => path.relative(baseDir, wrapperJar))
     .sort((a, b) => a.localeCompare(b))
+}
+
+export async function detectVersions(wrapperJars: string[]): Promise<string[]> {
+  return (
+    await Promise.all(
+      wrapperJars.map(async wrapperJar => await findWrapperVersion(wrapperJar))
+    )
+  ).filter(version => version !== undefined) as string[]
+}
+
+async function findWrapperVersion(
+  wrapperJar: string
+): Promise<string | undefined> {
+  const jar = path.parse(wrapperJar)
+  const properties = path.resolve(jar.dir, 'gradle-wrapper.properties')
+
+  if (fs.existsSync(properties)) {
+    try {
+      const lineReader = readline.createInterface({
+        input: fs.createReadStream(properties)
+      })
+
+      let distributionUrl = ''
+      lineReader.on('line', function (line) {
+        if (line.startsWith('distributionUrl=')) {
+          distributionUrl = line
+          lineReader.close()
+        }
+      })
+
+      await events.once(lineReader, 'close')
+
+      if (distributionUrl) {
+        const matchedVersion = distributionUrl.match(versionRegex)
+        if (matchedVersion && matchedVersion.length >= 1) {
+          return matchedVersion[1]
+        } else {
+          core.debug(
+            `Could not parse version from distributionUrl in gradle-wrapper.properties file: ${properties}`
+          )
+        }
+      } else {
+        core.debug(
+          `Could not identify valid distributionUrl in gradle-wrapper.properties file: ${properties}`
+        )
+      }
+    } catch (error) {
+      core.warning(
+        `Failed to retrieve version from gradle-wrapper.properties file: ${properties} due to ${error}`
+      )
+    }
+  } else {
+    core.debug(
+      `No gradle-wrapper.properties file existed alongside ${wrapperJar}`
+    )
+  }
+  return undefined
 }
 
 async function recursivelyListFiles(baseDir: string): Promise<string[]> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,8 @@ export async function run(): Promise<void> {
       path.resolve('.'),
       +core.getInput('min-wrapper-count'),
       core.getInput('allow-snapshots') === 'true',
-      core.getInput('allow-checksums').split(',')
+      core.getInput('allow-checksums').split(','),
+      core.getInput('detect-version') === 'true'
     )
     if (result.isValid()) {
       core.info(result.toDisplayString())

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -6,7 +6,8 @@ export async function findInvalidWrapperJars(
   gitRepoRoot: string,
   minWrapperCount: number,
   allowSnapshots: boolean,
-  allowChecksums: string[]
+  allowChecksums: string[],
+  detectVersions: boolean
 ): Promise<ValidationResult> {
   const wrapperJars = await find.findWrapperJars(gitRepoRoot)
   const result = new ValidationResult([], [])
@@ -16,7 +17,17 @@ export async function findInvalidWrapperJars(
     )
   }
   if (wrapperJars.length > 0) {
-    const validChecksums = await checksums.fetchValidChecksums(allowSnapshots)
+    let detectedVersions: string[]
+    if (detectVersions) {
+      detectedVersions = await find.detectVersions(wrapperJars)
+    } else {
+      detectedVersions = []
+    }
+    const validChecksums = await checksums.fetchValidChecksums(
+      allowSnapshots,
+      detectVersions,
+      detectedVersions
+    )
     validChecksums.push(...allowChecksums)
     for (const wrapperJar of wrapperJars) {
       const sha = await hash.sha256File(wrapperJar)


### PR DESCRIPTION
I do understand that this PR does not match the "contribution guideline" specifically on the requirement for:
> It is not the goal of this action to verify that the `gradle-wrapper.jar` matches a specific version of Gradle, nor that the version declared in the `build.gradle` or `gradle-wrapper.properties` file matches.
https://github.com/gradle/wrapper-validation-action/blob/56b90f209b02bf6d1deae490e9ef18b21a389cd4/CONTRIBUTING.md#non-goals

However, seeing related issues still being kept open - and overall comments indicate positive interest towards such a functionality (E.g. https://github.com/gradle/wrapper-validation-action/issues/96#issuecomment-1485976132, https://github.com/gradle/wrapper-validation-action/issues/35#issuecomment-802728301)

It would be great to see this functionality being added as I believe this will speed up the validation as a whole, but also lower the network utilization. Especially as recently the occurrences for request timeouts seem to increase (with builds frequently failing) - Related tickets # 46, # 40, 

--------

This PR introduces a new configuration option (which is disabled by default) called `detect-version`. 

When enabled the action will now try to retrieve the gradle version associated with a gradle wrapper via the `distributionUrl` in the `gradle-wrapper.properties`. 

Furthermore, it adjusts the checksum fetching condition to only retrieve checksums for the detected versions (instead of fetching versions for all possible releases). 

This PR aims to fix to open issue: https://github.com/gradle/wrapper-validation-action/issues/96

However, while it was not specifically designed for this purpose it partially resolves https://github.com/gradle/wrapper-validation-action/issues/142 as it will only include checksums for versions detected.
A future update could include that we retain wrapper <-> version && checksum <-> version details to only validate the specific combination. 

Additionally, I believe that the initial discovery and parsing of the `gradle-wrapper.properties` unlock and enable future expansions to for example handle: https://github.com/gradle/wrapper-validation-action/issues/35

-----

The PR includes the relevant changes to the action and updated test cases to cover the new functionality. 
