### PR TITLE
Update README to use `actions/checkout@v4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
 ```
 


### PR DESCRIPTION
This pull request updates the `README.md` guidance to use the newer `actions/checkout@v4` version.