### PR TITLE
Hardcoded checksums follow-up

### DIFF
--- a/.github/workflows/update-checksums-file.yml
+++ b/.github/workflows/update-checksums-file.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create or update pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: wrapper-checksums-update
+          branch: bot/wrapper-checksums-update
           commit-message: Update known wrapper checksums
           title: Update known wrapper checksums
           # Note: Unfortunately this action cannot trigger the regular workflows for the PR automatically, see

--- a/__tests__/checksums.test.ts
+++ b/__tests__/checksums.test.ts
@@ -4,9 +4,32 @@ import {afterEach, describe, expect, test, jest} from '@jest/globals'
 
 jest.setTimeout(30000)
 
+test('has loaded hardcoded wrapper jars checksums', async () => {
+  // Sanity check that generated checksums file is not empty and was properly imported
+  expect(checksums.KNOWN_VALID_CHECKSUMS.size).toBeGreaterThan(10)
+  // Verify that checksums of arbitrary versions are contained
+  expect(
+    checksums.KNOWN_VALID_CHECKSUMS.get(
+      '660ab018b8e319e9ae779fdb1b7ac47d0321bde953bf0eb4545f14952cfdcaa3'
+    )
+  ).toEqual(new Set(['4.10.3']))
+  expect(
+    checksums.KNOWN_VALID_CHECKSUMS.get(
+      '28b330c20a9a73881dfe9702df78d4d78bf72368e8906c70080ab6932462fe9e'
+    )
+  ).toEqual(new Set(['6.0-rc-1', '6.0-rc-2', '6.0-rc-3', '6.0', '6.0.1']))
+})
+
 test('fetches wrapper jars checksums', async () => {
   const validChecksums = await checksums.fetchValidChecksums(false)
   expect(validChecksums.size).toBeGreaterThan(10)
+  // Verify that checksum of arbitrary version is contained
+  expect(
+    validChecksums.has(
+      // Checksum for version 6.0
+      '28b330c20a9a73881dfe9702df78d4d78bf72368e8906c70080ab6932462fe9e'
+    )
+  ).toBe(true)
 })
 
 describe('retry', () => {


### PR DESCRIPTION
Follow-up for the review feedback on #167

- Added `bot/` prefix to branch name of automatically generated pull request
- Added tests verifying that `KNOWN_VALID_CHECKSUMS` is not empty