### PR TITLE
Log multiple errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28050,7 +28050,13 @@ async function run() {
         }
     }
     catch (error) {
-        if (error instanceof Error) {
+        if (error instanceof AggregateError) {
+            core.setFailed(`Multiple errors returned`);
+            for (const err of error.errors) {
+                core.error(`Error ${error.errors.indexOf(err)}: ${err.message}`);
+            }
+        }
+        else if (error instanceof Error) {
             core.setFailed(error.message);
         }
         else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,12 @@ export async function run(): Promise<void> {
       }
     }
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof AggregateError) {
+      core.setFailed(`Multiple errors returned`)
+      for (const err of error.errors) {
+        core.error(`Error ${error.errors.indexOf(err)}: ${err.message}`)
+      }
+    } else if (error instanceof Error) {
       core.setFailed(error.message)
     } else {
       core.setFailed(`Unknown object was thrown: ${error}`)


### PR DESCRIPTION
# What
Log AggregateError type, when multiple errors are returned from HTTP client - fixes #174

# Why
We would silently fail otherwise as error.message was empty for the AggregatedError exception.